### PR TITLE
Feature/soroban sdk v0.10.0 + fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.14.1",
-    "soroban-client": "^0.9.2",
+    "soroban-client": "0.10.1",
     "stellar-wallets-kit": "github:Creit-Tech/Stellar-Wallets-Kit"
   }
 }

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
   "dependencies": {
     "@stellar/design-system": "^1.0.0-beta.12",
     "@stellar/freighter-api": "^1.4.0",
+    "bignumber.js": "^9.1.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.14.1",

--- a/src/components/atomic-swap/exchange.tsx
+++ b/src/components/atomic-swap/exchange.tsx
@@ -169,7 +169,8 @@ export const Exchange = (props: ExchangeProps) => {
           );
 
           const originalFootprintXDR = xdr.LedgerFootprint.fromXDR(
-            Buffer.from(originalFootprint, "base64"),
+            originalFootprint,
+            "base64",
           );
 
           const final = TransactionBuilder.cloneFrom(preparedTransaction)

--- a/src/components/atomic-swap/exchange.tsx
+++ b/src/components/atomic-swap/exchange.tsx
@@ -173,7 +173,9 @@ export const Exchange = (props: ExchangeProps) => {
             "base64",
           );
 
-          const final = TransactionBuilder.cloneFrom(preparedTransaction)
+          const finalTransaction = TransactionBuilder.cloneFrom(
+            preparedTransaction,
+          )
             .setSorobanData(
               new SorobanDataBuilder(txSim.transactionData)
                 .setFootprint(
@@ -185,7 +187,7 @@ export const Exchange = (props: ExchangeProps) => {
             .build();
 
           const _signedXdr = await signTx(
-            final.toXDR(),
+            finalTransaction.toXDR(),
             props.pubKey,
             props.swkKit,
           );

--- a/src/components/atomic-swap/exchange.tsx
+++ b/src/components/atomic-swap/exchange.tsx
@@ -1,12 +1,12 @@
 import React, { ChangeEvent } from "react";
 import {
+  assembleTransaction,
   BASE_FEE,
   Memo,
   MemoType,
   Operation,
   Transaction,
   TransactionBuilder,
-  xdr,
 } from "soroban-client";
 import {
   Button,
@@ -31,7 +31,6 @@ import { NetworkDetails, signTx } from "../../helpers/network";
 import {
   getServer,
   submitTx,
-  assembleTransaction,
   getTxBuilder,
   buildSwap,
 } from "../../helpers/soroban";
@@ -62,7 +61,6 @@ export const Exchange = (props: ExchangeProps) => {
   const [amountB, setAmountB] = React.useState("");
   const [minAmountB, setMinAmountB] = React.useState("");
   const [swapperBAddress, setSwapperBAddress] = React.useState("");
-  const [originalFootprint, setOriginalFootprint] = React.useState("");
   const [fee, setFee] = React.useState(BASE_FEE);
   const [memo, setMemo] = React.useState("");
 
@@ -158,9 +156,6 @@ export const Exchange = (props: ExchangeProps) => {
             tx,
             props.networkDetails.networkPassphrase,
             txSim,
-            xdr.LedgerFootprint.fromXDR(
-              Buffer.from(originalFootprint, "base64"),
-            ),
           );
 
           const _signedXdr = await signTx(
@@ -243,7 +238,7 @@ export const Exchange = (props: ExchangeProps) => {
             minAmount: BigInt(minAmountB).toString(),
           };
 
-          const { preparedTransaction, footprint } = await buildSwap(
+          const preparedTransaction = await buildSwap(
             contractID,
             tokenA,
             tokenB,
@@ -254,7 +249,6 @@ export const Exchange = (props: ExchangeProps) => {
             props.networkDetails.networkPassphrase,
             txBuilder,
           );
-          setOriginalFootprint(footprint);
 
           const newWindow = window.open(
             `${props.basePath}/swapper-a`,

--- a/src/components/atomic-swap/swapper-A.tsx
+++ b/src/components/atomic-swap/swapper-A.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import BigNumber from "bignumber.js";
 import {
   Memo,
   MemoType,
@@ -22,10 +23,12 @@ import {
 } from "../../helpers/soroban";
 import { NetworkDetails } from "../../helpers/network";
 import { ERRORS } from "../../helpers/error";
+import { formatTokenAmount } from "../../helpers/format";
 
 type StepCount = 1 | 2;
 
 interface SwapperAProps {
+  decimals: number;
   basePath: string;
   networkDetails: NetworkDetails;
   setError: (error: string | null) => void;
@@ -86,7 +89,26 @@ export const SwapperA = (props: SwapperAProps) => {
           tx.toEnvelope().toXDR("base64"),
           props.networkDetails.networkPassphrase,
         );
-        setSwapArgs(args);
+        const formattedArgs = {
+          ...args,
+          amountA: formatTokenAmount(
+            new BigNumber(args.amountA),
+            props.decimals,
+          ),
+          amountB: formatTokenAmount(
+            new BigNumber(args.amountB),
+            props.decimals,
+          ),
+          minAForB: formatTokenAmount(
+            new BigNumber(args.minAForB),
+            props.decimals,
+          ),
+          minBForA: formatTokenAmount(
+            new BigNumber(args.minBForA),
+            props.decimals,
+          ),
+        };
+        setSwapArgs(formattedArgs);
 
         return;
       }

--- a/src/components/atomic-swap/swapper-B.tsx
+++ b/src/components/atomic-swap/swapper-B.tsx
@@ -161,12 +161,12 @@ export const SwapperB = (props: SwapperBProps) => {
       case 2: {
         const signWithWallet = async () => {
           try {
-            const signedAuth = await signAuthEntry();
+            const _signedTx = await signAuthEntry();
             bc.postMessage({
               type: ChannelMessageType.SignedTx,
               data: {
                 contractID,
-                signedTx: signedAuth,
+                signedTx: _signedTx,
               },
             });
 

--- a/src/components/atomic-swap/swapper-B.tsx
+++ b/src/components/atomic-swap/swapper-B.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import BigNumber from "bignumber.js";
 import { Button, Heading, Select, Profile } from "@stellar/design-system";
 import {
   Transaction,
@@ -25,10 +26,12 @@ import {
   BASE_FEE,
 } from "../../helpers/soroban";
 import { ERRORS } from "../../helpers/error";
+import { formatTokenAmount } from "../../helpers/format";
 
 type StepCount = 1 | 2 | 3;
 
 interface SwapperBProps {
+  decimals: number;
   networkDetails: NetworkDetails;
   setError: (error: string | null) => void;
   setPubKey: (pubKey: string) => void;
@@ -93,7 +96,26 @@ export const SwapperB = (props: SwapperBProps) => {
             tx.toEnvelope().toXDR("base64"),
             props.networkDetails.networkPassphrase,
           );
-          setSwapArgs(args);
+          const formattedArgs = {
+            ...args,
+            amountA: formatTokenAmount(
+              new BigNumber(args.amountA),
+              props.decimals,
+            ),
+            amountB: formatTokenAmount(
+              new BigNumber(args.amountB),
+              props.decimals,
+            ),
+            minAForB: formatTokenAmount(
+              new BigNumber(args.minAForB),
+              props.decimals,
+            ),
+            minBForA: formatTokenAmount(
+              new BigNumber(args.minBForA),
+              props.decimals,
+            ),
+          };
+          setSwapArgs(formattedArgs);
 
           const tokenASymbolBuilder = await getTxBuilder(
             publicKey,

--- a/src/helpers/format.ts
+++ b/src/helpers/format.ts
@@ -1,0 +1,44 @@
+import BigNumber from "bignumber.js";
+
+// used for display purposes
+export const truncateString = (str: string) =>
+  str ? `${str.slice(0, 5)}…${str.slice(-5)}` : "";
+
+// conversion used to display the base fee
+export const stroopToXlm = (
+  stroops: BigNumber | string | number,
+): BigNumber => {
+  if (stroops instanceof BigNumber) {
+    return stroops.dividedBy(1e7);
+  }
+  return new BigNumber(Number(stroops) / 1e7);
+};
+
+export const xlmToStroop = (lumens: BigNumber | string): BigNumber => {
+  if (lumens instanceof BigNumber) {
+    return lumens.times(1e7);
+  }
+  // round to nearest stroop
+  return new BigNumber(Math.round(Number(lumens) * 1e7));
+};
+
+// With a tokens set number of decimals, display the formatted value for an amount.
+// Example - User A has 1000000001 of a token set to 7 decimals, display should be 100.0000001
+export const formatTokenAmount = (amount: BigNumber, decimals: number) => {
+  let formatted = amount.toString();
+
+  if (decimals > 0) {
+    formatted = amount.shiftedBy(-decimals).toFixed(decimals).toString();
+
+    // Trim trailing zeros
+    while (formatted[formatted.length - 1] === "0") {
+      formatted = formatted.substring(0, formatted.length - 1);
+    }
+
+    if (formatted.endsWith(".")) {
+      formatted = formatted.substring(0, formatted.length - 1);
+    }
+  }
+
+  return formatted;
+};

--- a/src/helpers/soroban.ts
+++ b/src/helpers/soroban.ts
@@ -287,14 +287,6 @@ export const buildContractAuth = async (
           return Buffer.from(signature.data);
         };
 
-        // eslint-disable-next-line no-await-in-loop
-        // const authEntry = await authorizeInvocationCallback(
-        //   signerPubKey,
-        //   signingMethod as any as (input: Buffer) => Buffer, // TODO: types in stellar-base not correct?
-        //   networkPassphrase, // does this need to be passphrase hash?
-        //   expirationLedgerSeq,
-        //   invocation
-        // )
         const entryNonce = entry.credentials().address().nonce();
         const preimage = buildAuthEnvelope(
           networkPassphrase,

--- a/src/helpers/soroban.ts
+++ b/src/helpers/soroban.ts
@@ -270,12 +270,7 @@ export const buildContractAuth = async (
         const input = hash(preimage.toXDR());
         // eslint-disable-next-line no-await-in-loop
         const signature = await signingMethod(input);
-        const authEntry = buildAuthEntry(
-          preimage,
-          signature,
-          signerPubKey,
-          entryNonce,
-        );
+        const authEntry = buildAuthEntry(preimage, signature, signerPubKey);
 
         signedAuthEntries.push(authEntry);
       } else {
@@ -304,12 +299,7 @@ function buildAuthEnvelope(
   return xdr.HashIdPreimage.envelopeTypeSorobanAuthorization(envelope);
 }
 
-function buildAuthEntry(
-  envelope: any,
-  signature: any,
-  publicKey: string,
-  nonce: any,
-) {
+function buildAuthEntry(envelope: any, signature: any, publicKey: string) {
   // ensure this identity signed this envelope correctly
   if (
     !Keypair.fromPublicKey(publicKey).verify(hash(envelope.toXDR()), signature)
@@ -331,7 +321,7 @@ function buildAuthEntry(
     credentials: xdr.SorobanCredentials.sorobanCredentialsAddress(
       new xdr.SorobanAddressCredentials({
         address: new Address(publicKey).toScAddress(),
-        nonce,
+        nonce: auth.nonce(),
         signatureExpirationLedger: auth.signatureExpirationLedger(),
         signatureArgs: [
           nativeToScVal(

--- a/src/helpers/soroban.ts
+++ b/src/helpers/soroban.ts
@@ -157,11 +157,22 @@ export const buildSwap = async (
     tx.addMemo(Memo.text(memo));
   }
 
+  const built = tx.build();
+  const sim = await server.simulateTransaction(built);
   const preparedTransaction = (await server.prepareTransaction(
     tx.build(),
     networkPassphrase,
   )) as Transaction<Memo<MemoType>, Operation[]>;
-  return preparedTransaction;
+
+  const sorobanTxData = xdr.SorobanTransactionData.fromXDR(
+    sim.transactionData,
+    "base64",
+  );
+
+  return {
+    preparedTransaction,
+    footprint: sorobanTxData.resources().footprint().toXDR("base64"),
+  };
 };
 
 // Get the tokens symbol, decoded as a string

--- a/src/helpers/soroban.ts
+++ b/src/helpers/soroban.ts
@@ -346,6 +346,12 @@ export const getArgsFromEnvelope = (
   }
 
   const args = op.invokeContract();
+  const tokenA = StrKey.encodeContract(
+    Buffer.from(args[4].address().contractId().toString("hex"), "hex"),
+  );
+  const tokenB = StrKey.encodeContract(
+    Buffer.from(args[5].address().contractId().toString("hex"), "hex"),
+  );
 
   return {
     addressA: StrKey.encodeEd25519PublicKey(
@@ -354,8 +360,8 @@ export const getArgsFromEnvelope = (
     addressB: StrKey.encodeEd25519PublicKey(
       args[3].address().accountId().ed25519(),
     ),
-    tokenA: args[4].address().contractId().toString("hex"),
-    tokenB: args[5].address().contractId().toString("hex"),
+    tokenA,
+    tokenB,
     amountA: valueToI128String(args[6]),
     minBForA: valueToI128String(args[7]),
     amountB: valueToI128String(args[8]),

--- a/src/helpers/soroban.ts
+++ b/src/helpers/soroban.ts
@@ -161,7 +161,7 @@ export const buildSwap = async (
   const built = tx.build();
   const sim = await server.simulateTransaction(built);
   const preparedTransaction = assembleTransaction(
-    tx.build(),
+    built,
     networkPassphrase,
     sim,
   ) as Transaction<Memo<MemoType>, Operation[]>;

--- a/src/helpers/soroban.ts
+++ b/src/helpers/soroban.ts
@@ -274,8 +274,6 @@ export const buildContractAuth = async (
           preimage,
           signature,
           signerPubKey,
-          invocation,
-          expirationLedgerSeq,
           entryNonce,
         );
 
@@ -295,10 +293,7 @@ function buildAuthEnvelope(
   invocation: any,
   nonce: any,
 ) {
-  const networkId = Buffer.from(hash(Buffer.from(networkPassphrase))).subarray(
-    0,
-    32,
-  );
+  const networkId = hash(Buffer.from(networkPassphrase));
   const envelope = new xdr.HashIdPreimageSorobanAuthorization({
     networkId,
     invocation,
@@ -313,8 +308,6 @@ function buildAuthEntry(
   envelope: any,
   signature: any,
   publicKey: string,
-  invocation: any,
-  signatureExpirationLedger: any,
   nonce: any,
 ) {
   // ensure this identity signed this envelope correctly
@@ -332,13 +325,14 @@ function buildAuthEntry(
     );
   }
 
+  const auth = envelope.sorobanAuthorization();
   return new xdr.SorobanAuthorizationEntry({
-    rootInvocation: invocation,
+    rootInvocation: auth.invocation(),
     credentials: xdr.SorobanCredentials.sorobanCredentialsAddress(
       new xdr.SorobanAddressCredentials({
         address: new Address(publicKey).toScAddress(),
         nonce,
-        signatureExpirationLedger,
+        signatureExpirationLedger: auth.signatureExpirationLedger(),
         signatureArgs: [
           nativeToScVal(
             {

--- a/src/helpers/soroban.ts
+++ b/src/helpers/soroban.ts
@@ -17,6 +17,7 @@ import {
   xdr,
   scValToBigInt,
   ScInt,
+  assembleTransaction,
 } from "soroban-client";
 import { StellarWalletsKit } from "stellar-wallets-kit";
 
@@ -159,10 +160,11 @@ export const buildSwap = async (
 
   const built = tx.build();
   const sim = await server.simulateTransaction(built);
-  const preparedTransaction = (await server.prepareTransaction(
+  const preparedTransaction = assembleTransaction(
     tx.build(),
     networkPassphrase,
-  )) as Transaction<Memo<MemoType>, Operation[]>;
+    sim,
+  ) as Transaction<Memo<MemoType>, Operation[]>;
 
   const sorobanTxData = xdr.SorobanTransactionData.fromXDR(
     sim.transactionData,

--- a/src/helpers/soroban.ts
+++ b/src/helpers/soroban.ts
@@ -440,12 +440,8 @@ export const getArgsFromEnvelope = (
   }
 
   const args = op.invokeContract();
-  const tokenA = StrKey.encodeContract(
-    Buffer.from(args[4].address().contractId().toString("hex"), "hex"),
-  );
-  const tokenB = StrKey.encodeContract(
-    Buffer.from(args[5].address().contractId().toString("hex"), "hex"),
-  );
+  const tokenA = StrKey.encodeContract(args[4].address().contractId());
+  const tokenB = StrKey.encodeContract(args[5].address().contractId());
 
   return {
     addressA: StrKey.encodeEd25519PublicKey(

--- a/src/helpers/soroban.ts
+++ b/src/helpers/soroban.ts
@@ -20,6 +20,7 @@ import {
   hash,
   nativeToScVal,
 } from "soroban-client";
+import BigNumber from "bignumber.js";
 import { StellarWalletsKit } from "stellar-wallets-kit";
 
 import { NetworkDetails, signData } from "./network";
@@ -46,6 +47,40 @@ export const BASE_FEE = "100";
 
 export const RPC_URLS: { [key: string]: string } = {
   FUTURENET: "https://rpc-futurenet.stellar.org:443",
+};
+
+// Given a display value for a token and a number of decimals, return the corresponding BigNumber
+export const parseTokenAmount = (value: string, decimals: number) => {
+  const comps = value.split(".");
+
+  let whole = comps[0];
+  let fraction = comps[1];
+  if (!whole) {
+    whole = "0";
+  }
+  if (!fraction) {
+    fraction = "0";
+  }
+
+  // Trim trailing zeros
+  while (fraction[fraction.length - 1] === "0") {
+    fraction = fraction.substring(0, fraction.length - 1);
+  }
+
+  // If decimals is 0, we have an empty string for fraction
+  if (fraction === "") {
+    fraction = "0";
+  }
+
+  // Fully pad the string with zeros to get to value
+  while (fraction.length < decimals) {
+    fraction += "0";
+  }
+
+  const wholeValue = new BigNumber(whole);
+  const fractionValue = new BigNumber(fraction);
+
+  return wholeValue.shiftedBy(decimals).plus(fractionValue);
 };
 
 export const accountToScVal = (account: string) =>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -31,6 +31,8 @@ const App = (props: AppProps) => {
   // Initial state, empty states for token/transaction details
   const [activePubKey, setActivePubKey] = React.useState("");
   const [error, setError] = React.useState(null as string | null);
+  const [tokenADecimals, setTokenADecimals] = React.useState(0);
+  const [tokenBDecimals, setTokenBDecimals] = React.useState(0);
 
   // Setup swc, user will set the desired wallet on connect
   const [SWKKit] = React.useState(
@@ -61,6 +63,10 @@ const App = (props: AppProps) => {
               networkDetails={selectedNetwork}
               setError={setError}
               setPubKey={setActivePubKey}
+              setTokenADecimals={setTokenADecimals}
+              setTokenBDecimals={setTokenBDecimals}
+              tokenADecimals={tokenADecimals}
+              tokenBDecimals={tokenBDecimals}
               swkKit={SWKKit}
               pubKey={activePubKey}
             />
@@ -71,6 +77,7 @@ const App = (props: AppProps) => {
           element: (
             <SwapperA
               basePath={window.location.origin}
+              decimals={tokenADecimals}
               networkDetails={selectedNetwork}
               setError={setError}
               setPubKey={setActivePubKey}
@@ -83,6 +90,7 @@ const App = (props: AppProps) => {
           path: "swapper-b/",
           element: (
             <SwapperB
+              decimals={tokenBDecimals}
               networkDetails={selectedNetwork}
               setError={setError}
               setPubKey={setActivePubKey}

--- a/src/sub-router.tsx
+++ b/src/sub-router.tsx
@@ -33,6 +33,8 @@ export const AppSubRouter = (props: AppProps) => {
   // Initial state, empty states for token/transaction details
   const [activePubKey, setActivePubKey] = React.useState("");
   const [error, setError] = React.useState(null as string | null);
+  const [tokenADecimals, setTokenADecimals] = React.useState(0);
+  const [tokenBDecimals, setTokenBDecimals] = React.useState(0);
 
   // Setup swc, user will set the desired wallet on connect
   const [SWKKit] = React.useState(
@@ -67,6 +69,10 @@ export const AppSubRouter = (props: AppProps) => {
               networkDetails={selectedNetwork}
               setError={setError}
               setPubKey={setActivePubKey}
+              setTokenADecimals={setTokenADecimals}
+              setTokenBDecimals={setTokenBDecimals}
+              tokenADecimals={tokenADecimals}
+              tokenBDecimals={tokenBDecimals}
               swkKit={SWKKit}
               pubKey={activePubKey}
             />
@@ -77,6 +83,7 @@ export const AppSubRouter = (props: AppProps) => {
           element={
             <SwapperA
               basePath={basePath}
+              decimals={tokenADecimals}
               networkDetails={selectedNetwork}
               setError={setError}
               setPubKey={setActivePubKey}
@@ -89,6 +96,7 @@ export const AppSubRouter = (props: AppProps) => {
           path="swapper-b/"
           element={
             <SwapperB
+              decimals={tokenBDecimals}
               networkDetails={selectedNetwork}
               setError={setError}
               setPubKey={setActivePubKey}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2355,16 +2355,6 @@ arrify@^2.0.1:
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-2.0.1.tgz#c9655e9331e0abcd588d2a7cad7e9956f66701fa"
   integrity sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==
 
-asn1.js@^5.2.0:
-  version "5.4.1"
-  resolved "https://registry.yarnpkg.com/asn1.js/-/asn1.js-5.4.1.tgz#11a980b84ebb91781ce35b0fdc2ee294e3783f07"
-  integrity sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==
-  dependencies:
-    bn.js "^4.0.0"
-    inherits "^2.0.1"
-    minimalistic-assert "^1.0.0"
-    safer-buffer "^2.1.0"
-
 ast-types-flow@^0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
@@ -2502,16 +2492,6 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
 
-bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.11.9:
-  version "4.12.0"
-  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.0.tgz#775b3f278efbb9718eec7361f483fb36fbbfea88"
-  integrity sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==
-
-bn.js@^5.0.0, bn.js@^5.1.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.1.tgz#0bc527a6a0d18d0aa8d5b0538ce4a77dccfa7b70"
-  integrity sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==
-
 body-parser@1.20.1:
   version "1.20.1"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.20.1.tgz#b1812a8912c195cd371a3ee5e66faa2338a5c668"
@@ -2592,65 +2572,6 @@ broccoli-plugin@^4.0.7:
     rimraf "^3.0.2"
     symlink-or-copy "^1.3.1"
 
-brorand@^1.0.1, brorand@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
-  integrity sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==
-
-browserify-aes@^1.0.0, browserify-aes@^1.0.4:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/browserify-aes/-/browserify-aes-1.2.0.tgz#326734642f403dabc3003209853bb70ad428ef48"
-  integrity sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==
-  dependencies:
-    buffer-xor "^1.0.3"
-    cipher-base "^1.0.0"
-    create-hash "^1.1.0"
-    evp_bytestokey "^1.0.3"
-    inherits "^2.0.1"
-    safe-buffer "^5.0.1"
-
-browserify-cipher@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/browserify-cipher/-/browserify-cipher-1.0.1.tgz#8d6474c1b870bfdabcd3bcfcc1934a10e94f15f0"
-  integrity sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==
-  dependencies:
-    browserify-aes "^1.0.4"
-    browserify-des "^1.0.0"
-    evp_bytestokey "^1.0.0"
-
-browserify-des@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/browserify-des/-/browserify-des-1.0.2.tgz#3af4f1f59839403572f1c66204375f7a7f703e9c"
-  integrity sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==
-  dependencies:
-    cipher-base "^1.0.1"
-    des.js "^1.0.0"
-    inherits "^2.0.1"
-    safe-buffer "^5.1.2"
-
-browserify-rsa@^4.0.0, browserify-rsa@^4.0.1:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/browserify-rsa/-/browserify-rsa-4.1.0.tgz#b2fd06b5b75ae297f7ce2dc651f918f5be158c8d"
-  integrity sha512-AdEER0Hkspgno2aR97SAf6vi0y0k8NuOpGnVH3O99rcA5Q6sh8QxcngtHuJ6uXwnfAXNM4Gn1Gb7/MV1+Ymbog==
-  dependencies:
-    bn.js "^5.0.0"
-    randombytes "^2.0.1"
-
-browserify-sign@^4.0.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/browserify-sign/-/browserify-sign-4.2.1.tgz#eaf4add46dd54be3bb3b36c0cf15abbeba7956c3"
-  integrity sha512-/vrA5fguVAKKAVTNJjgSm1tRQDHUU6DbwO9IROu/0WAzC8PKhucDSh18J0RMvVeHAn5puMd+QHC2erPRNf8lmg==
-  dependencies:
-    bn.js "^5.1.1"
-    browserify-rsa "^4.0.1"
-    create-hash "^1.2.0"
-    create-hmac "^1.1.7"
-    elliptic "^6.5.3"
-    inherits "^2.0.4"
-    parse-asn1 "^5.1.5"
-    readable-stream "^3.6.0"
-    safe-buffer "^5.2.0"
-
 browserslist@^4.14.5, browserslist@^4.21.9:
   version "4.21.10"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.21.10.tgz#dbbac576628c13d3b2231332cb2ec5a46e015bb0"
@@ -2688,11 +2609,6 @@ buffer-from@^1.0.0, buffer-from@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
-
-buffer-xor@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
-  integrity sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==
 
 buffer@^5.4.3:
   version "5.7.1"
@@ -2830,14 +2746,6 @@ ci-info@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
   integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
-
-cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/cipher-base/-/cipher-base-1.0.4.tgz#8760e4ecc272f4c363532f926d874aae2c1397de"
-  integrity sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==
-  dependencies:
-    inherits "^2.0.1"
-    safe-buffer "^5.0.1"
 
 clean-css@^5.2.2, clean-css@~5.3.2:
   version "5.3.2"
@@ -3135,42 +3043,6 @@ cosmiconfig@^7.0.0:
     path-type "^4.0.0"
     yaml "^1.10.0"
 
-crc@^4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/crc/-/crc-4.3.2.tgz#49b7821cbf2cf61dfd079ed93863bbebd5469b9a"
-  integrity sha512-uGDHf4KLLh2zsHa8D8hIQ1H/HtFQhyHrc0uhHBcoKGol/Xnb+MPYfUMw7cvON6ze/GUESTudKayDcJC5HnJv1A==
-
-create-ecdh@^4.0.0:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/create-ecdh/-/create-ecdh-4.0.4.tgz#d6e7f4bffa66736085a0762fd3a632684dabcc4e"
-  integrity sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==
-  dependencies:
-    bn.js "^4.1.0"
-    elliptic "^6.5.3"
-
-create-hash@^1.1.0, create-hash@^1.1.2, create-hash@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/create-hash/-/create-hash-1.2.0.tgz#889078af11a63756bcfb59bd221996be3a9ef196"
-  integrity sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==
-  dependencies:
-    cipher-base "^1.0.1"
-    inherits "^2.0.1"
-    md5.js "^1.3.4"
-    ripemd160 "^2.0.1"
-    sha.js "^2.4.0"
-
-create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/create-hmac/-/create-hmac-1.1.7.tgz#69170c78b3ab957147b2b8b04572e47ead2243ff"
-  integrity sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==
-  dependencies:
-    cipher-base "^1.0.3"
-    create-hash "^1.1.0"
-    inherits "^2.0.1"
-    ripemd160 "^2.0.0"
-    safe-buffer "^5.0.1"
-    sha.js "^2.4.8"
-
 cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
@@ -3179,23 +3051,6 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
-
-crypto-browserify@^3.12.0:
-  version "3.12.0"
-  resolved "https://registry.yarnpkg.com/crypto-browserify/-/crypto-browserify-3.12.0.tgz#396cf9f3137f03e4b8e532c58f698254e00f80ec"
-  integrity sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==
-  dependencies:
-    browserify-cipher "^1.0.0"
-    browserify-sign "^4.0.0"
-    create-ecdh "^4.0.0"
-    create-hash "^1.1.0"
-    create-hmac "^1.1.0"
-    diffie-hellman "^5.0.0"
-    inherits "^2.0.1"
-    pbkdf2 "^3.0.3"
-    public-encrypt "^4.0.0"
-    randombytes "^2.0.0"
-    randomfill "^1.0.3"
 
 css-loader@^6.7.4:
   version "6.8.1"
@@ -3341,14 +3196,6 @@ dequal@^2.0.3:
   resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.3.tgz#2644214f1997d39ed0ee0ece72335490a7ac67be"
   integrity sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
 
-des.js@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/des.js/-/des.js-1.1.0.tgz#1d37f5766f3bbff4ee9638e871a8768c173b81da"
-  integrity sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==
-  dependencies:
-    inherits "^2.0.1"
-    minimalistic-assert "^1.0.0"
-
 destroy@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.2.0.tgz#4803735509ad8be552934c67df614f94e66fa015"
@@ -3368,15 +3215,6 @@ detect-node@^2.0.4:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.1.0.tgz#c9c70775a49c3d03bc2c06d9a73be550f978f8b1"
   integrity sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==
-
-diffie-hellman@^5.0.0:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/diffie-hellman/-/diffie-hellman-5.0.3.tgz#40e8ee98f55a2149607146921c63e1ae5f3d2875"
-  integrity sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==
-  dependencies:
-    bn.js "^4.1.0"
-    miller-rabin "^4.0.0"
-    randombytes "^2.0.0"
 
 dijkstrajs@^1.0.1:
   version "1.0.3"
@@ -3520,19 +3358,6 @@ electron-to-chromium@^1.4.477:
   version "1.4.478"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.478.tgz#687198cfcef9b854a79a229feaa6cd8961206290"
   integrity sha512-qjTA8djMXd+ruoODDFGnRCRBpID+AAfYWCyGtYTNhsuwxI19s8q19gbjKTwRS5z/LyVf5wICaIiPQGLekmbJbA==
-
-elliptic@^6.5.3:
-  version "6.5.4"
-  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.4.tgz#da37cebd31e79a1367e941b592ed1fbebd58abbb"
-  integrity sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==
-  dependencies:
-    bn.js "^4.11.9"
-    brorand "^1.1.0"
-    hash.js "^1.0.0"
-    hmac-drbg "^1.0.1"
-    inherits "^2.0.4"
-    minimalistic-assert "^1.0.1"
-    minimalistic-crypto-utils "^1.0.1"
 
 emoji-regex@^7.0.1:
   version "7.0.3"
@@ -3987,14 +3812,6 @@ eventsource@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/eventsource/-/eventsource-2.0.2.tgz#76dfcc02930fb2ff339520b6d290da573a9e8508"
   integrity sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==
-
-evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz#7fcbdb198dc71959432efe13842684e0525acb02"
-  integrity sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==
-  dependencies:
-    md5.js "^1.3.4"
-    safe-buffer "^5.1.1"
 
 execa@^4.0.0:
   version "4.1.0"
@@ -4558,23 +4375,6 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
-hash-base@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/hash-base/-/hash-base-3.1.0.tgz#55c381d9e06e1d2997a883b4a3fddfe7f0d3af33"
-  integrity sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==
-  dependencies:
-    inherits "^2.0.4"
-    readable-stream "^3.6.0"
-    safe-buffer "^5.2.0"
-
-hash.js@^1.0.0, hash.js@^1.0.3:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.7.tgz#0babca538e8d4ee4a0f8988d68866537a003cf42"
-  integrity sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==
-  dependencies:
-    inherits "^2.0.3"
-    minimalistic-assert "^1.0.1"
-
 he@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
@@ -4594,15 +4394,6 @@ heimdalljs@^0.2.6:
   integrity sha512-o9bd30+5vLBvBtzCPwwGqpry2+n0Hi6H1+qwt6y+0kwRHGGF8TFIhJPmnuM0xO97zaKrDZMwO/V56fAnn8m/tA==
   dependencies:
     rsvp "~3.2.1"
-
-hmac-drbg@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
-  integrity sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==
-  dependencies:
-    hash.js "^1.0.3"
-    minimalistic-assert "^1.0.0"
-    minimalistic-crypto-utils "^1.0.1"
 
 hpack.js@^2.1.6:
   version "2.1.6"
@@ -4880,7 +4671,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3:
+inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -5493,15 +5284,6 @@ matcher-collection@^2.0.0:
     "@types/minimatch" "^3.0.3"
     minimatch "^3.0.2"
 
-md5.js@^1.3.4:
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
-  integrity sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==
-  dependencies:
-    hash-base "^3.0.0"
-    inherits "^2.0.1"
-    safe-buffer "^5.1.2"
-
 media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
@@ -5542,14 +5324,6 @@ micromatch@^4.0.0, micromatch@^4.0.2, micromatch@^4.0.4, micromatch@^4.0.5:
     braces "^3.0.2"
     picomatch "^2.3.1"
 
-miller-rabin@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/miller-rabin/-/miller-rabin-4.0.1.tgz#f080351c865b0dc562a8462966daa53543c78a4d"
-  integrity sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==
-  dependencies:
-    bn.js "^4.0.0"
-    brorand "^1.0.1"
-
 mime-db@1.52.0, "mime-db@>= 1.43.0 < 2":
   version "1.52.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
@@ -5584,15 +5358,10 @@ mini-css-extract-plugin@^2.7.5:
   dependencies:
     schema-utils "^4.0.0"
 
-minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
+minimalistic-assert@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
   integrity sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==
-
-minimalistic-crypto-utils@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
-  integrity sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==
 
 minimatch@^3.0.2, minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"
@@ -5978,17 +5747,6 @@ parent-module@^1.0.0:
   dependencies:
     callsites "^3.0.0"
 
-parse-asn1@^5.0.0, parse-asn1@^5.1.5:
-  version "5.1.6"
-  resolved "https://registry.yarnpkg.com/parse-asn1/-/parse-asn1-5.1.6.tgz#385080a3ec13cb62a62d39409cb3e88844cdaed4"
-  integrity sha512-RnZRo1EPU6JBnra2vGHj0yhp6ebyjBZpmUCLHWiFhxlzvBCCpAuZ7elsBp1PVAbQN0/04VD/19rfzlBSwLstMw==
-  dependencies:
-    asn1.js "^5.2.0"
-    browserify-aes "^1.0.0"
-    evp_bytestokey "^1.0.0"
-    pbkdf2 "^3.0.3"
-    safe-buffer "^5.1.1"
-
 parse-json@^5.0.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-5.2.0.tgz#c76fc66dee54231c962b22bcc8a72cf2f99753cd"
@@ -6081,17 +5839,6 @@ path-type@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
-
-pbkdf2@^3.0.3:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.1.2.tgz#dd822aa0887580e52f1a039dc3eda108efae3075"
-  integrity sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==
-  dependencies:
-    create-hash "^1.1.2"
-    create-hmac "^1.1.4"
-    ripemd160 "^2.0.1"
-    safe-buffer "^5.0.1"
-    sha.js "^2.4.8"
 
 picocolors@^1.0.0:
   version "1.0.0"
@@ -6293,18 +6040,6 @@ proxy-from-env@^1.1.0:
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
   integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
-public-encrypt@^4.0.0:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/public-encrypt/-/public-encrypt-4.0.3.tgz#4fcc9d77a07e48ba7527e7cbe0de33d0701331e0"
-  integrity sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==
-  dependencies:
-    bn.js "^4.1.0"
-    browserify-rsa "^4.0.0"
-    create-hash "^1.1.0"
-    parse-asn1 "^5.0.0"
-    randombytes "^2.0.1"
-    safe-buffer "^5.1.2"
-
 pump@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pump/-/pump-2.0.1.tgz#12399add6e4cf7526d973cbc8b5ce2e2908b3909"
@@ -6384,19 +6119,11 @@ quick-temp@^0.1.8:
     rimraf "^2.5.4"
     underscore.string "~3.3.4"
 
-randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.1.0:
+randombytes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
   integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
   dependencies:
-    safe-buffer "^5.1.0"
-
-randomfill@^1.0.3:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/randomfill/-/randomfill-1.0.4.tgz#c92196fc86ab42be983f1bf31778224931d61458"
-  integrity sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==
-  dependencies:
-    randombytes "^2.0.5"
     safe-buffer "^5.1.0"
 
 range-parser@^1.2.1, range-parser@~1.2.1:
@@ -6457,7 +6184,7 @@ react@^18.2.0:
   dependencies:
     loose-envify "^1.1.0"
 
-readable-stream@3, readable-stream@^3.0.2, readable-stream@^3.0.6, readable-stream@^3.1.1, readable-stream@^3.6.0:
+readable-stream@3, readable-stream@^3.0.2, readable-stream@^3.0.6, readable-stream@^3.1.1:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.2.tgz#56a9b36ea965c00c5a93ef31eb111a0f11056967"
   integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
@@ -6711,14 +6438,6 @@ rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
-ripemd160@^2.0.0, ripemd160@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.2.tgz#a1c1a6f624751577ba5d07914cbc92850585890c"
-  integrity sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==
-  dependencies:
-    hash-base "^3.0.0"
-    inherits "^2.0.1"
-
 rsvp@^4.8.2:
   version "4.8.5"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734"
@@ -6758,7 +6477,7 @@ safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
-safe-buffer@5.2.1, safe-buffer@>=5.1.0, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@~5.2.0:
+safe-buffer@5.2.1, safe-buffer@>=5.1.0, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -6782,7 +6501,7 @@ safe-stable-stringify@^2.1.0:
   resolved "https://registry.yarnpkg.com/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz#138c84b6f6edb3db5f8ef3ef7115b8f55ccbf886"
   integrity sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==
 
-"safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.1.0:
+"safer-buffer@>= 2.1.2 < 3":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
@@ -6927,7 +6646,7 @@ setprototypeof@1.2.0:
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
-sha.js@^2.3.6, sha.js@^2.4.0, sha.js@^2.4.8:
+sha.js@^2.3.6:
   version "2.4.11"
   resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.11.tgz#37a5cf0b81ecbc6943de109ba2960d1b26584ae7"
   integrity sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==
@@ -7032,10 +6751,10 @@ sonic-boom@^2.2.1:
   dependencies:
     atomic-sleep "^1.0.0"
 
-soroban-client@^0.9.2:
-  version "0.9.2"
-  resolved "https://registry.yarnpkg.com/soroban-client/-/soroban-client-0.9.2.tgz#5abe4ab69abc7af9a152038bef550f7e2a72ec6e"
-  integrity sha512-PPQLvAQTF/y56ev9V9wdMze/K49u1Cj6F9rkiUlRy++wCpSAVjiRYG+duolYvjkzUFPon56xlgAc7tuP4EolWA==
+soroban-client@0.10.1:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/soroban-client/-/soroban-client-0.10.1.tgz#b1c42d7e4629cad9e2cdfec1dbc692c87ec9209f"
+  integrity sha512-MAyDllFm7FETzwmdS+uGEp15TToo1aYtUxnVCs4dMl/f7P8Lb6whW664dYfyjvh8+mUOlVf+dlBY1qgJFlnDLQ==
   dependencies:
     axios "^1.4.0"
     bignumber.js "^9.1.1"
@@ -7045,7 +6764,7 @@ soroban-client@^0.9.2:
     eventsource "^2.0.2"
     lodash "^4.17.21"
     randombytes "^2.1.0"
-    stellar-base "10.0.0-soroban.4"
+    stellar-base "10.0.0-soroban.6"
     toml "^3.0.0"
     urijs "^1.19.1"
 
@@ -7145,16 +6864,14 @@ statuses@2.0.1:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==
 
-stellar-base@10.0.0-soroban.4:
-  version "10.0.0-soroban.4"
-  resolved "https://registry.yarnpkg.com/stellar-base/-/stellar-base-10.0.0-soroban.4.tgz#9baeaec1f750473cb0dc00c6fa0f3ec23cf7177d"
-  integrity sha512-Afl2Mlh+aXokIHhy2x67Df5ofbss83oAOHV7pHLI0fsPlxAgs7YtbClzkNxvpnXyxQI77PMIWFJbT17Y3dR/+A==
+stellar-base@10.0.0-soroban.6:
+  version "10.0.0-soroban.6"
+  resolved "https://registry.yarnpkg.com/stellar-base/-/stellar-base-10.0.0-soroban.6.tgz#b63e3d8e49866a0d1386b2f418c25cb0700f3457"
+  integrity sha512-672OQgps7BjyCvrQywOn7vc/NaaexsH2WrBl+EjlKMDsRp/na0fZcM7+053r9FYzK8nCcXgbOd5IXM6Hmb1pog==
   dependencies:
     base32.js "^0.1.0"
     bignumber.js "^9.1.1"
     buffer "^6.0.3"
-    crc "^4.3.2"
-    crypto-browserify "^3.12.0"
     js-xdr "^3.0.0"
     sha.js "^2.3.6"
     tweetnacl "^1.0.3"


### PR DESCRIPTION
This updates to use the new sdk version, and removes some logic that can now be handled by the sdk.

There is still some discussion going on around building auth entries, so likely when we figure [this one ](https://github.com/stellar/js-stellar-base/pull/675/commits/e688c2dacd755de8892a66ff4e26e3e9f1eb00e9)out we can refactor even more out of the dapp.

Removes shimmed `assembleTransaction` in favor of the sdk version now that it can use existing auth entries.
Brings in copies of the helpers - `buildAuthEntry`, `buildAuthEnvelope`, in order to pass through nonce, and once the PR above lands we should be able to delete these as well.
Adds `parseTokenAmount` and `formatTokenAmount` in order to properly handle tokens with decimals set(I had forgotten because I have been testing with 0 decimal tokens 😄 )
Uses getDecimals to properly parse and format token amounts.