### PR TITLE
Replace formatters and parser with the new sdk version

### DIFF
--- a/src/components/atomic-swap/exchange.tsx
+++ b/src/components/atomic-swap/exchange.tsx
@@ -7,6 +7,7 @@ import {
   Operation,
   SorobanDataBuilder,
   SorobanRpc,
+  Soroban,
   Transaction,
   TransactionBuilder,
   xdr,
@@ -37,7 +38,6 @@ import {
   getTxBuilder,
   buildSwap,
   getTokenDecimals,
-  parseTokenAmount,
 } from "../../helpers/soroban";
 import { ERRORS } from "../../helpers/error";
 
@@ -264,8 +264,11 @@ export const Exchange = (props: ExchangeProps) => {
 
           const tokenA = {
             id: tokenAAddress,
-            amount: parseTokenAmount(amountA, props.tokenADecimals).toString(),
-            minAmount: parseTokenAmount(
+            amount: Soroban.parseTokenAmount(
+              amountA,
+              props.tokenADecimals,
+            ).toString(),
+            minAmount: Soroban.parseTokenAmount(
               minAmountA,
               props.tokenADecimals,
             ).toString(),
@@ -273,8 +276,11 @@ export const Exchange = (props: ExchangeProps) => {
 
           const tokenB = {
             id: tokenBAddress,
-            amount: parseTokenAmount(amountB, props.tokenBDecimals).toString(),
-            minAmount: parseTokenAmount(
+            amount: Soroban.parseTokenAmount(
+              amountB,
+              props.tokenBDecimals,
+            ).toString(),
+            minAmount: Soroban.parseTokenAmount(
               minAmountB,
               props.tokenBDecimals,
             ).toString(),

--- a/src/components/atomic-swap/swapper-A.tsx
+++ b/src/components/atomic-swap/swapper-A.tsx
@@ -6,6 +6,7 @@ import {
   Operation,
   Transaction,
   TransactionBuilder,
+  Soroban,
 } from "soroban-client";
 import { Button, Heading, Select, Profile } from "@stellar/design-system";
 import {
@@ -23,7 +24,6 @@ import {
 } from "../../helpers/soroban";
 import { NetworkDetails } from "../../helpers/network";
 import { ERRORS } from "../../helpers/error";
-import { formatTokenAmount } from "../../helpers/format";
 
 type StepCount = 1 | 2;
 
@@ -91,19 +91,19 @@ export const SwapperA = (props: SwapperAProps) => {
         );
         const formattedArgs = {
           ...args,
-          amountA: formatTokenAmount(
+          amountA: Soroban.formatTokenAmount(
             new BigNumber(args.amountA),
             props.decimals,
           ),
-          amountB: formatTokenAmount(
+          amountB: Soroban.formatTokenAmount(
             new BigNumber(args.amountB),
             props.decimals,
           ),
-          minAForB: formatTokenAmount(
+          minAForB: Soroban.formatTokenAmount(
             new BigNumber(args.minAForB),
             props.decimals,
           ),
-          minBForA: formatTokenAmount(
+          minBForA: Soroban.formatTokenAmount(
             new BigNumber(args.minBForA),
             props.decimals,
           ),

--- a/src/components/atomic-swap/swapper-B.tsx
+++ b/src/components/atomic-swap/swapper-B.tsx
@@ -7,6 +7,7 @@ import {
   Memo,
   MemoType,
   Operation,
+  Soroban,
 } from "soroban-client";
 import {
   WalletNetwork,
@@ -26,7 +27,6 @@ import {
   BASE_FEE,
 } from "../../helpers/soroban";
 import { ERRORS } from "../../helpers/error";
-import { formatTokenAmount } from "../../helpers/format";
 
 type StepCount = 1 | 2 | 3;
 
@@ -100,19 +100,19 @@ export const SwapperB = (props: SwapperBProps) => {
           );
           const formattedArgs = {
             ...args,
-            amountA: formatTokenAmount(
+            amountA: Soroban.formatTokenAmount(
               new BigNumber(args.amountA),
               props.decimals,
             ),
-            amountB: formatTokenAmount(
+            amountB: Soroban.formatTokenAmount(
               new BigNumber(args.amountB),
               props.decimals,
             ),
-            minAForB: formatTokenAmount(
+            minAForB: Soroban.formatTokenAmount(
               new BigNumber(args.minAForB),
               props.decimals,
             ),
-            minBForA: formatTokenAmount(
+            minBForA: Soroban.formatTokenAmount(
               new BigNumber(args.minBForA),
               props.decimals,
             ),

--- a/src/helpers/format.ts
+++ b/src/helpers/format.ts
@@ -21,24 +21,3 @@ export const xlmToStroop = (lumens: BigNumber | string): BigNumber => {
   // round to nearest stroop
   return new BigNumber(Math.round(Number(lumens) * 1e7));
 };
-
-// With a tokens set number of decimals, display the formatted value for an amount.
-// Example - User A has 1000000001 of a token set to 7 decimals, display should be 100.0000001
-export const formatTokenAmount = (amount: BigNumber, decimals: number) => {
-  let formatted = amount.toString();
-
-  if (decimals > 0) {
-    formatted = amount.shiftedBy(-decimals).toFixed(decimals).toString();
-
-    // Trim trailing zeros
-    while (formatted[formatted.length - 1] === "0") {
-      formatted = formatted.substring(0, formatted.length - 1);
-    }
-
-    if (formatted.endsWith(".")) {
-      formatted = formatted.substring(0, formatted.length - 1);
-    }
-  }
-
-  return formatted;
-};

--- a/src/helpers/soroban.ts
+++ b/src/helpers/soroban.ts
@@ -17,7 +17,6 @@ import {
   assembleTransaction,
   hash,
 } from "soroban-client";
-import BigNumber from "bignumber.js";
 import { StellarWalletsKit } from "stellar-wallets-kit";
 
 import { NetworkDetails, signData } from "./network";
@@ -37,40 +36,6 @@ export const BASE_FEE = "100";
 
 export const RPC_URLS: { [key: string]: string } = {
   FUTURENET: "https://rpc-futurenet.stellar.org:443",
-};
-
-// Given a display value for a token and a number of decimals, return the corresponding BigNumber
-export const parseTokenAmount = (value: string, decimals: number) => {
-  const comps = value.split(".");
-
-  let whole = comps[0];
-  let fraction = comps[1];
-  if (!whole) {
-    whole = "0";
-  }
-  if (!fraction) {
-    fraction = "0";
-  }
-
-  // Trim trailing zeros
-  while (fraction[fraction.length - 1] === "0") {
-    fraction = fraction.substring(0, fraction.length - 1);
-  }
-
-  // If decimals is 0, we have an empty string for fraction
-  if (fraction === "") {
-    fraction = "0";
-  }
-
-  // Fully pad the string with zeros to get to value
-  while (fraction.length < decimals) {
-    fraction += "0";
-  }
-
-  const wholeValue = new BigNumber(whole);
-  const fractionValue = new BigNumber(fraction);
-
-  return wholeValue.shiftedBy(decimals).plus(fractionValue);
 };
 
 export const accountToScVal = (account: string) =>


### PR DESCRIPTION
Ticket: [Remove formatters and parser from soroban-react-mint-token and use new sdk version](https://stellarorg.atlassian.net/browse/WAL-992)

**Summary:**
- replaced `formatTokenAmount` with `Soroban.formatTokenAmount`
- replaced `parseTokenAmount` with `Soroban.parseTokenAmount`